### PR TITLE
Fix: Ensure proper return value in silero VAD encoding function

### DIFF
--- a/sense-voice/csrc/silero-vad.cc
+++ b/sense-voice/csrc/silero-vad.cc
@@ -199,4 +199,5 @@ bool silero_vad_encode_internal(sense_voice_context &ctx,
         }
         ggml_backend_tensor_get(ggml_graph_get_tensor(gf, "logit"), &speech_prob, 0, sizeof(speech_prob));
     }
+    return true;
 }


### PR DESCRIPTION
注意：这里会导致报错，甚至建议迁移tag的位置。